### PR TITLE
Fix D1_ERROR: not authorized

### DIFF
--- a/src/routes/api/db/[database]/+server.ts
+++ b/src/routes/api/db/[database]/+server.ts
@@ -33,6 +33,10 @@ export const GET: RequestHandler = async ({ params, locals, url, fetch, platform
 		throw error(404, "No tables found");
 	}
 	const results = tables.results.filter(({ name }) => {
+		// Avoid all Cloudflare internal table names.
+		if (name.startsWith("_cf_")) {
+			return false;
+		}
 		if (name.startsWith("sqlite_") || name.startsWith("d1_")) {
 			return !!platform?.env.SHOW_INTERNAL_TABLES;
 		}


### PR DESCRIPTION
- we're trying to read an internal table column - given we have no authority to do so during runtime, the query to get columns will fail and result the error.
- tested in prod, now it works out of the box with my build with this fix. 