### PR TITLE
Support Cloudflare AI Worker

### DIFF
--- a/.changeset/popular-pets-smell.md
+++ b/.changeset/popular-pets-smell.md
@@ -1,0 +1,5 @@
+---
+"d1-manager": minor
+---
+
+Support Cloudflare AI as query builder

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ node_modules
 !.env.example
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+cfai/

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 
 cfai/
+.wrangler/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ D1 Manager is a web UI and API for Cloudflare D1, a serverless SQL database. It 
 -   [x] List all tables in a database
 -   [x] Show table schema
 -   [x] Run SQL queries
--   [x] Run Semantic Queries (with `OPENAI_API_KEY` env var set)
+-   [x] Run Semantic Queries (OpenAI API or Cloudflare AI Worker)
 -   [x] Edit table data through UI
 -   [x] I18n support (English, Chinese, Spanish, Japanese) [add more](./locales/)
 -   [x] API support (see [routes/api](./src/routes/api/) for details)
@@ -34,9 +34,22 @@ Some plugins (e.g. Semantic Query) require additional environment variables to b
 
 Also, there are some configuration options that can be set through environment variables.
 
--   `SHOW_INTERNAL_TABLES`: Show internal tables (`splite_*` and `d1_*`) in the UI.
--   `OPENAI_API_KEY`: OpenAI API key for Semantic Query.
--   `OPENAI_API_URL`: You may use this with Cloudflare AI Gateway to proxy requests to OpenAI API.
+- `SHOW_INTERNAL_TABLES`: Show internal tables (`splite_*` and `d1_*`) in the UI.
+
+#### Semantic Query
+
+You can use OpenAI API or Cloudflare AI Worker to run Semantic Query.
+
+OpenAI API:
+
+- `OPENAI_API_KEY`: OpenAI API key for Semantic Query.
+- `OPENAI_API_URL`: You may use this with Cloudflare AI Gateway to proxy requests to OpenAI API.
+- `OPENAI_MODEL`: OpenAI API model for Semantic Query. Default to `gpt-3.5-turbo-1106`.
+
+Cloudflare AI Worker:
+
+- `AI`: Bind a Cloudflare AI Worker to this variable.
+- `CFAI_MODEL`: Cloudflare AI Worker model for Semantic Query. Default to `@cf/mistral/mistral-7b-instruct-v0.1`.
 
 ## Screenshots
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -9,13 +9,14 @@
 	},
 	"d1-manager-manage-db": "Use D1 Manager to mange data in {db}",
 	"download": "Download",
+	"execute-sql-query-in-database": "Execute SQL query in database {db}",
 	"lang": {
 		"en": "English",
-		"zh-CN": "Simplified Chinese",
-		"zh-TW": "Traditional Chinese",
-		"es-MX": "Mexican Spanish",
 		"es-ES": "Spanish from Spain",
-		"ja": "Japanese"
+		"es-MX": "Mexican Spanish",
+		"ja": "Japanese",
+		"zh-CN": "Simplified Chinese",
+		"zh-TW": "Traditional Chinese"
 	},
 	"language": "Language",
 	"n-ms": "{n} ms",

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -9,13 +9,14 @@
 	},
 	"d1-manager-manage-db": "Usa D1 Manager para gestionar datos en {db}",
 	"download": "Descargar",
+	"execute-sql-query-in-database": "Ejecutar consulta SQL en la base de datos {db}",
 	"lang": {
 		"en": "Inglés",
-		"zh-CN": "Chino simplificado",
-		"zh-TW": "Chino tradicional",
-		"es-MX": "Español mexicano",
 		"es-ES": "Español de españa",
-		"ja": "Japonés"
+		"es-MX": "Español mexicano",
+		"ja": "Japonés",
+		"zh-CN": "Chino simplificado",
+		"zh-TW": "Chino tradicional"
 	},
 	"language": "Idioma",
 	"n-ms": "{n} ms",

--- a/locales/es-MX.json
+++ b/locales/es-MX.json
@@ -9,13 +9,14 @@
 	},
 	"d1-manager-manage-db": "Usa D1 Manager para gestionar datos en {db}",
 	"download": "Descargar",
+	"execute-sql-query-in-database": "Ejecutar consulta SQL en la base de datos {db}",
 	"lang": {
 		"en": "Inglés",
-		"zh-CN": "Chino simplificado",
-		"zh-TW": "Chino tradicional",
-		"es-MX": "Español mexicano",
 		"es-ES": "Español de españa",
-		"ja": "Japonés"
+		"es-MX": "Español mexicano",
+		"ja": "Japonés",
+		"zh-CN": "Chino simplificado",
+		"zh-TW": "Chino tradicional"
 	},
 	"language": "Idioma",
 	"n-ms": "{n} ms",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -9,13 +9,14 @@
 	},
 	"d1-manager-manage-db": "D1 Manager を使用して {db} 内のデータを管理",
 	"download": "ダウンロード",
+	"execute-sql-query-in-database": "データベース {db} で SQL クエリを実行します",
 	"lang": {
 		"en": "英語",
-		"zh-CN": "簡体字中国語",
-		"zh-TW": "繁体字中国語",
-		"es-MX": "メキシコスペイン語",
 		"es-ES": "スペイン語",
-		"ja": "日本語"
+		"es-MX": "メキシコスペイン語",
+		"ja": "日本語",
+		"zh-CN": "簡体字中国語",
+		"zh-TW": "繁体字中国語"
 	},
 	"language": "言語",
 	"n-ms": "{n} ミリ秒かかりました",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -9,13 +9,14 @@
 	},
 	"d1-manager-manage-db": "使用 D1 Manager 管理 {db} 中的资料",
 	"download": "下载",
+	"execute-sql-query-in-database": "在数据库 {db} 中执行 SQL 查询",
 	"lang": {
 		"en": "英语",
-		"zh-CN": "简体中文",
-		"zh-TW": "繁体中文",
-		"es-MX": "墨西哥西班牙语",
 		"es-ES": "西班牙语",
-		"ja": "日语"
+		"es-MX": "墨西哥西班牙语",
+		"ja": "日语",
+		"zh-CN": "简体中文",
+		"zh-TW": "繁体中文"
 	},
 	"language": "语言",
 	"n-ms": "花费 {n} 毫秒",

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -9,13 +9,14 @@
 	},
 	"d1-manager-manage-db": "使用 D1 Manager 管理 {db} 中的資料",
 	"download": "下載",
+	"execute-sql-query-in-database": "在資料庫 {db} 中執行 SQL 查詢",
 	"lang": {
 		"en": "英語",
-		"zh-CN": "簡體中文",
-		"zh-TW": "正體中文",
-		"es-MX": "墨西哥西班牙語",
 		"es-ES": "西班牙語",
-		"ja": "日語"
+		"es-MX": "墨西哥西班牙語",
+		"ja": "日語",
+		"zh-CN": "簡體中文",
+		"zh-TW": "正體中文"
 	},
 	"language": "語言",
 	"n-ms": "花費 {n} 毫秒",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		".svelte-kit/cloudflare"
 	],
 	"scripts": {
-		"prepare": "husky install",
+		"prepare": "husky install && tsup src/cfai.ts -d cfai --format esm --minify",
 		"dev": "vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
@@ -24,6 +24,7 @@
 		"@ai-d/aid": "^0.1.5",
 		"@changesets/changelog-github": "^0.5.0",
 		"@changesets/cli": "^2.27.1",
+		"@cloudflare/ai": "^1.0.47",
 		"@cloudflare/workers-types": "^4.20240117.0",
 		"@iconify/svelte": "^3.1.6",
 		"@playwright/test": "^1.41.1",
@@ -56,6 +57,7 @@
 		"tailwindcss": "^3.4.1",
 		"theme-change": "2.5.0",
 		"tslib": "^2.6.2",
+		"tsup": "^8.0.1",
 		"typescript": "^5.3.3",
 		"vite": "^5.0.12",
 		"vitest": "^0.34.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ devDependencies:
     "@changesets/cli":
         specifier: ^2.27.1
         version: 2.27.1
+    "@cloudflare/ai":
+        specifier: ^1.0.47
+        version: 1.0.47
     "@cloudflare/workers-types":
         specifier: ^4.20240117.0
         version: 4.20240117.0
@@ -110,6 +113,9 @@ devDependencies:
     tslib:
         specifier: ^2.6.2
         version: 2.6.2
+    tsup:
+        specifier: ^8.0.1
+        version: 8.0.1(postcss@8.4.33)(typescript@5.3.3)
     typescript:
         specifier: ^5.3.3
         version: 5.3.3
@@ -472,6 +478,13 @@ packages:
             fs-extra: 7.0.1
             human-id: 1.0.2
             prettier: 2.8.8
+        dev: true
+
+    /@cloudflare/ai@1.0.47:
+        resolution:
+            {
+                integrity: sha512-HRCIrSPrC3mXtIhbWQsSZAQxKHeiQxsjLPy0LHPrkZMzIFevJREINSNEhEccU/kDREkyPlzU5vV4++Yldbqqsg==,
+            }
         dev: true
 
     /@cloudflare/kv-asset-handler@0.2.0:
@@ -2608,6 +2621,19 @@ packages:
             }
         dev: true
 
+    /bundle-require@4.0.2(esbuild@0.19.12):
+        resolution:
+            {
+                integrity: sha512-jwzPOChofl67PSTW2SGubV9HBQAhhR2i6nskiOThauo9dzwDUgOWQScFVaJkjEfYX+UXiD+LEx8EblQMc2wIag==,
+            }
+        engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+        peerDependencies:
+            esbuild: ">=0.17"
+        dependencies:
+            esbuild: 0.19.12
+            load-tsconfig: 0.2.5
+        dev: true
+
     /cac@6.7.14:
         resolution:
             {
@@ -3799,6 +3825,24 @@ packages:
             }
         dev: true
 
+    /execa@5.1.1:
+        resolution:
+            {
+                integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==,
+            }
+        engines: { node: ">=10" }
+        dependencies:
+            cross-spawn: 7.0.3
+            get-stream: 6.0.1
+            human-signals: 2.1.0
+            is-stream: 2.0.1
+            merge-stream: 2.0.0
+            npm-run-path: 4.0.1
+            onetime: 5.1.2
+            signal-exit: 3.0.7
+            strip-final-newline: 2.0.0
+        dev: true
+
     /execa@8.0.1:
         resolution:
             {
@@ -3858,20 +3902,6 @@ packages:
             {
                 integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==,
             }
-        dev: true
-
-    /fast-glob@3.2.12:
-        resolution:
-            {
-                integrity: sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==,
-            }
-        engines: { node: ">=8.6.0" }
-        dependencies:
-            "@nodelib/fs.stat": 2.0.5
-            "@nodelib/fs.walk": 1.2.8
-            glob-parent: 5.1.2
-            merge2: 1.4.1
-            micromatch: 4.0.5
         dev: true
 
     /fast-glob@3.3.2:
@@ -4165,6 +4195,14 @@ packages:
             source-map: 0.6.1
         dev: true
 
+    /get-stream@6.0.1:
+        resolution:
+            {
+                integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==,
+            }
+        engines: { node: ">=10" }
+        dev: true
+
     /get-stream@8.0.1:
         resolution:
             {
@@ -4275,7 +4313,7 @@ packages:
         dependencies:
             array-union: 2.1.0
             dir-glob: 3.0.1
-            fast-glob: 3.2.12
+            fast-glob: 3.3.2
             ignore: 5.2.4
             merge2: 1.4.1
             slash: 3.0.0
@@ -4416,6 +4454,14 @@ packages:
             {
                 integrity: sha512-UNopramDEhHJD+VR+ehk8rOslwSfByxPIZyJRfV739NDhN5LF1fa1MqnzKm2lGTQRjNrjK19Q5fhkgIfjlVUKw==,
             }
+        dev: true
+
+    /human-signals@2.1.0:
+        resolution:
+            {
+                integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==,
+            }
+        engines: { node: ">=10.17.0" }
         dev: true
 
     /human-signals@5.0.0:
@@ -4750,6 +4796,14 @@ packages:
             call-bind: 1.0.2
         dev: true
 
+    /is-stream@2.0.1:
+        resolution:
+            {
+                integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==,
+            }
+        engines: { node: ">=8" }
+        dev: true
+
     /is-stream@3.0.0:
         resolution:
             {
@@ -4832,6 +4886,14 @@ packages:
                 integrity: sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==,
             }
         hasBin: true
+        dev: true
+
+    /joycon@3.1.1:
+        resolution:
+            {
+                integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==,
+            }
+        engines: { node: ">=10" }
         dev: true
 
     /js-tokens@4.0.0:
@@ -4993,6 +5055,14 @@ packages:
             wrap-ansi: 9.0.0
         dev: true
 
+    /load-tsconfig@0.2.5:
+        resolution:
+            {
+                integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==,
+            }
+        engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+        dev: true
+
     /load-yaml-file@0.2.0:
         resolution:
             {
@@ -5059,6 +5129,13 @@ packages:
         resolution:
             {
                 integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==,
+            }
+        dev: true
+
+    /lodash.sortby@4.7.0:
+        resolution:
+            {
+                integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==,
             }
         dev: true
 
@@ -5529,6 +5606,16 @@ packages:
                 integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==,
             }
         engines: { node: ">=0.10.0" }
+        dev: true
+
+    /npm-run-path@4.0.1:
+        resolution:
+            {
+                integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==,
+            }
+        engines: { node: ">=8" }
+        dependencies:
+            path-key: 3.1.1
         dev: true
 
     /npm-run-path@5.1.0:
@@ -6769,6 +6856,16 @@ packages:
         engines: { node: ">=0.10.0" }
         dev: true
 
+    /source-map@0.8.0-beta.0:
+        resolution:
+            {
+                integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==,
+            }
+        engines: { node: ">= 8" }
+        dependencies:
+            whatwg-url: 7.1.0
+        dev: true
+
     /sourcemap-codec@1.4.8:
         resolution:
             {
@@ -6949,6 +7046,14 @@ packages:
                 integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==,
             }
         engines: { node: ">=4" }
+        dev: true
+
+    /strip-final-newline@2.0.0:
+        resolution:
+            {
+                integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==,
+            }
+        engines: { node: ">=6" }
         dev: true
 
     /strip-final-newline@3.0.0:
@@ -7340,6 +7445,23 @@ packages:
             }
         dev: true
 
+    /tr46@1.0.1:
+        resolution:
+            {
+                integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==,
+            }
+        dependencies:
+            punycode: 2.3.0
+        dev: true
+
+    /tree-kill@1.2.2:
+        resolution:
+            {
+                integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==,
+            }
+        hasBin: true
+        dev: true
+
     /trim-newlines@3.0.1:
         resolution:
             {
@@ -7372,6 +7494,49 @@ packages:
             {
                 integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==,
             }
+        dev: true
+
+    /tsup@8.0.1(postcss@8.4.33)(typescript@5.3.3):
+        resolution:
+            {
+                integrity: sha512-hvW7gUSG96j53ZTSlT4j/KL0q1Q2l6TqGBFc6/mu/L46IoNWqLLUzLRLP1R8Q7xrJTmkDxxDoojV5uCVs1sVOg==,
+            }
+        engines: { node: ">=18" }
+        hasBin: true
+        peerDependencies:
+            "@microsoft/api-extractor": ^7.36.0
+            "@swc/core": ^1
+            postcss: ^8.4.12
+            typescript: ">=4.5.0"
+        peerDependenciesMeta:
+            "@microsoft/api-extractor":
+                optional: true
+            "@swc/core":
+                optional: true
+            postcss:
+                optional: true
+            typescript:
+                optional: true
+        dependencies:
+            bundle-require: 4.0.2(esbuild@0.19.12)
+            cac: 6.7.14
+            chokidar: 3.5.3
+            debug: 4.3.4
+            esbuild: 0.19.12
+            execa: 5.1.1
+            globby: 11.1.0
+            joycon: 3.1.1
+            postcss: 8.4.33
+            postcss-load-config: 4.0.1(postcss@8.4.33)
+            resolve-from: 5.0.0
+            rollup: 4.6.1
+            source-map: 0.8.0-beta.0
+            sucrase: 3.32.0
+            tree-kill: 1.2.2
+            typescript: 5.3.3
+        transitivePeerDependencies:
+            - supports-color
+            - ts-node
         dev: true
 
     /tty-table@4.1.6:
@@ -7738,6 +7903,13 @@ packages:
             }
         dev: true
 
+    /webidl-conversions@4.0.2:
+        resolution:
+            {
+                integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==,
+            }
+        dev: true
+
     /whatwg-url@5.0.0:
         resolution:
             {
@@ -7746,6 +7918,17 @@ packages:
         dependencies:
             tr46: 0.0.3
             webidl-conversions: 3.0.1
+        dev: true
+
+    /whatwg-url@7.1.0:
+        resolution:
+            {
+                integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==,
+            }
+        dependencies:
+            lodash.sortby: 4.7.0
+            tr46: 1.0.1
+            webidl-conversions: 4.0.2
         dev: true
 
     /which-boxed-primitive@1.0.2:

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -11,6 +11,7 @@ declare global {
 			env: {
 				SHOW_INTERNAL_TABLES?: string;
 				OPENAI_API_KEY?: string;
+				AI?: unknown;
 			} & Record<string, Fetcher | string>;
 		}
 	}

--- a/src/cfai.ts
+++ b/src/cfai.ts
@@ -1,0 +1,1 @@
+export * from "@cloudflare/ai";

--- a/src/lib/plugin/SemanticQuery.svelte
+++ b/src/lib/plugin/SemanticQuery.svelte
@@ -53,9 +53,9 @@
 		running = true;
 
 		try {
-			const res = await fetch(`/api/plugin/semantic-query`, {
+			const res = await fetch(`/api/db/${database}/assistant`, {
 				method: "POST",
-				body: JSON.stringify({ q: query, t: [[table, cols], ...others] }),
+				body: JSON.stringify({ q: query, t: table }),
 			});
 
 			const json = await res.json<{ sql: string } | typeof error>();

--- a/src/lib/plugin/SemanticQuery.svelte
+++ b/src/lib/plugin/SemanticQuery.svelte
@@ -6,18 +6,6 @@
 
 	export let database: string;
 	export let table: string;
-	export let data: PluginData;
-
-	const cols: [string, string][] =
-		data.db
-			.find(({ name }) => name === table)
-			?.columns.sort(({ cid: a }, { cid: b }) => a - b)
-			.map(({ name, type }) => [name, type]) || [];
-	const others: [string, [string, string][]][] = data.db
-		.filter(
-			({ name }) => name !== table && !name.startsWith("sqlite_") && !name.startsWith("d1_"),
-		)
-		.map(({ name, columns }) => [name, columns.map(({ name, type }) => [name, type])]);
 
 	let query = $t("show-first-10-records", { values: { table } });
 
@@ -79,6 +67,9 @@
 	}
 
 	async function run() {
+		if (!suggestion) {
+			return;
+		}
 		if (running) {
 			return;
 		}

--- a/src/lib/plugin/SemanticQuery.svelte
+++ b/src/lib/plugin/SemanticQuery.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { t } from "svelte-i18n";
-	import type { PluginData } from "./type";
 	import { is_dangerous, is_readonly } from "../sql";
 	import { export_csv } from "$lib/csv";
 
@@ -173,7 +172,7 @@
 {#if result}
 	<div class="divider" />
 
-	{#if result.results.length}
+	{#if result.results?.length}
 		<div class="max-h-[80vh] overflow-auto">
 			<table class="table-sm table w-full">
 				<thead>
@@ -211,7 +210,7 @@
 				},
 			})}
 		</p>
-		{#if result?.results.length}
+		{#if result.results?.length}
 			<button
 				class="btn-primary btn-outline btn-sm btn"
 				on:click={() => (result ? export_csv(result.results, table) : undefined)}

--- a/src/lib/server/ai/index.ts
+++ b/src/lib/server/ai/index.ts
@@ -1,0 +1,56 @@
+import { env } from "$env/dynamic/private";
+import type { BaseChatMessage, BaseChatMessageRole, BaseChatParam } from "@ai-d/aid";
+import { Aid } from "@ai-d/aid";
+import debug from "debug";
+
+debug.enable("aid*");
+
+const log = debug("assistant");
+log.enabled = true;
+
+export type AiBackend =
+	| Aid<
+			string,
+			BaseChatParam,
+			BaseChatMessage<BaseChatMessageRole>[],
+			BaseChatMessage<BaseChatMessageRole>[]
+	  >
+	| undefined;
+
+export async function select_backend(): Promise<AiBackend> {
+	if (env.OPENAI_API_KEY) {
+		log("using OpenAI backend");
+		const { OpenAI } = await import("openai");
+		const model = env.OPENAI_MODEL || "gpt-3.5-turbo-1106";
+		return Aid.from(
+			new OpenAI({
+				baseURL: env.OPENAI_API_URL,
+				apiKey: env.OPENAI_API_KEY,
+			}),
+			{ model },
+		);
+	}
+
+	if (env.AI) {
+		log("using Cloudflare backend");
+		return Aid.chat(async (messages) => {
+			const { Ai } = await import("$lib/../../cfai/cfai");
+			const ai = new Ai(env.AI);
+			const model = env.CFAI_MODEL || "@cf/mistral/mistral-7b-instruct-v0.1";
+			const { response } = await ai.run(model, {
+				messages,
+			});
+
+			const res: string = response;
+			const match = res.match(/{\s*"sql":\s*".*?"\s*}/);
+			if (match) {
+				return match[0];
+			}
+
+			return res;
+		});
+	}
+
+	log("no backend");
+	return undefined;
+}

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,6 +1,8 @@
+import { available } from "$lib/server/ai";
 import type { LayoutServerLoad } from "./$types";
 
 export const load: LayoutServerLoad = async ({ fetch }) => {
 	const dbms = await fetch("/api/db").then((r) => r.json<string[]>());
-	return { dbms };
+	const assistant = available();
+	return { dbms, assistant };
 };

--- a/src/routes/api/+server.ts
+++ b/src/routes/api/+server.ts
@@ -1,0 +1,12 @@
+import { version } from "$app/environment";
+import { available } from "$lib/server/ai";
+import { json } from "@sveltejs/kit";
+import type { RequestHandler } from "./$types";
+
+export const GET: RequestHandler = async ({ locals }) => {
+	return json({
+		db: Object.keys(locals.db),
+		assistant: available(),
+		version,
+	});
+};

--- a/src/routes/api/db/[database]/+server.ts
+++ b/src/routes/api/db/[database]/+server.ts
@@ -51,7 +51,9 @@ export const GET: RequestHandler = async ({ params, locals, url, fetch, platform
 		}),
 	);
 
-	const columns = (await _columns).map(({ results }) => results);
+	const columns = (await _columns).map(
+		({ results }) => results as { name: string; type: string }[],
+	);
 	const count = (await _count).map(({ results }) => results?.[0].c);
 
 	const response = results

--- a/src/routes/api/db/[database]/all/+server.ts
+++ b/src/routes/api/db/[database]/all/+server.ts
@@ -5,7 +5,11 @@ import type { RequestHandler } from "./$types";
 export const POST: RequestHandler = async ({ request, params, locals, url, fetch }) => {
 	if (dev) {
 		const remote = new URL("https://d1-manager.pages.dev" + url.pathname + url.search);
-		const res = await fetch(remote, { method: "POST", body: await request.text() });
+		const res = await fetch(remote, {
+			method: "POST",
+			body: await request.text(),
+			headers: request.headers,
+		});
 		return json(await res.json());
 	}
 

--- a/src/routes/api/db/[database]/assistant/+server.ts
+++ b/src/routes/api/db/[database]/assistant/+server.ts
@@ -8,19 +8,38 @@ import type { RequestHandler } from "./$types";
 
 debug.enable("aid*");
 
-export const POST: RequestHandler = async ({ request }) => {
+export const POST: RequestHandler = async ({ params, request, fetch }) => {
 	const OPENAI_API_KEY = env.OPENAI_API_KEY;
 	if (typeof OPENAI_API_KEY !== "string") {
 		return json({ error: "OPENAI_API_KEY is not set" });
 	}
 
+	const tables_p = fetch("/api/db/" + params.database).then((r) =>
+		r.json<
+			{
+				name: string;
+				columns: { name: string; type: string }[];
+				count: number;
+			}[]
+		>(),
+	);
+
 	const data = await request.json<{
 		q: string;
-		t: [name: string, cols: [name: string, type: string][]][];
+		t?: string;
 	}>();
 
+	const tables = await tables_p;
+
+	// if t is provided, swap the table t with the first table
+	if (data.t) {
+		const i = tables.findIndex(({ name }) => name === data.t);
+		if (i > 0) {
+			[tables[0], tables[i]] = [tables[i], tables[0]];
+		}
+	}
+
 	const question = data.q || "show first 10 records in the table";
-	const tables = data.t;
 
 	const openai = new OpenAI({
 		baseURL: env.OPENAI_API_URL,
@@ -31,7 +50,10 @@ export const POST: RequestHandler = async ({ request }) => {
 	const system = `SQLite tables, with their properties:
 
 ${tables
-	.map(([name, cols]) => `${name} (${cols.map(([name, type]) => `${name}: ${type}`).join(", ")})`)
+	.map(
+		({ name, columns }) =>
+			`${name} (${columns.map(({ name, type }) => `${name}: ${type}`).join(", ")})`,
+	)
 	.join("\n")}
 
 write a raw SQL, without comment`;

--- a/src/routes/db/[database]/+page.svelte
+++ b/src/routes/db/[database]/+page.svelte
@@ -73,7 +73,9 @@
 				<textarea
 					class="textarea-bordered textarea h-10 flex-1 resize-y !rounded-l-lg font-mono transition-colors focus:textarea-primary join-item"
 					class:!outline-error={danger}
-					placeholder="Execute SQL query in database {$page.params.database}"
+					placeholder={$t("execute-sql-query-in-database", {
+						values: { db: $page.params.database },
+					})}
 					bind:value={query}
 					on:keypress={handler}
 					disabled={running}


### PR DESCRIPTION
- This PR adds support for using Cloudflare AI Worker as the semantic query builder.
Users can enable this by binding `AI` environment variable to the Cloudflare AI Worker.
- The `/api` endpoint can be used to check the system health, including the databases bound, the semantic query builder backend selected, and the timestamp of the build.