### PR TITLE
Fixed issue identifying and parsing errors on client (SQL execution input)

### DIFF
--- a/src/routes/db/[database]/+page.svelte
+++ b/src/routes/db/[database]/+page.svelte
@@ -38,8 +38,11 @@
 
 			const json = await res.json<any>();
 			if (json) {
-				if ("error" in json) {
-					error = json?.error?.cause || json?.error?.message;
+				if (res.status == 500 && json.code == 400) {
+					error = json?.message;
+					duration = undefined;
+				} else if (res.status == 500) {
+					error = "An unknown error has occurred.  Check the browser devtools for more.";
 					duration = undefined;
 				} else {
 					duration = json.duration;


### PR DESCRIPTION
The frontend currently expects "error" to be in the response json and the message to be at error.cause or error.message.

The exec endpoint actually returns it in this format:
STATUS: 500
`{
code: 400,
message: "error message here"
}`

Im not sure if this was due to a change that happened and broke this, or if it was never implemented in the first place, but I fixed it now.