### PR TITLE
feat: update default model to gpt-4.1-mini in README and source code

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
               uses: actions/checkout@v4
 
             - name: Setup PNPM
-              uses: pnpm/action-setup@v2.2.4
+              uses: pnpm/action-setup@v4
               with:
                   run_install: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
               uses: actions/checkout@v4
 
             - name: Setup PNPM
-              uses: pnpm/action-setup@v2.2.4
+              uses: pnpm/action-setup@v4
               with:
                   run_install: true
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ OpenAI API:
 
 - `OPENAI_API_KEY`: OpenAI API key for Semantic Query.
 - `OPENAI_API_URL`: You may use this with Cloudflare AI Gateway to proxy requests to OpenAI API.
-- `OPENAI_MODEL`: OpenAI API model for Semantic Query. Default to `gpt-3.5-turbo-1106`.
+- `OPENAI_MODEL`: OpenAI API model for Semantic Query. Default to `gpt-4.1-mini`.
 
 Cloudflare AI Worker:
 
@@ -67,4 +67,4 @@ Cloudflare AI Worker:
 
 ![semantic-query](./images/semantic-query.png)
 
-> Semantic Query uses OpenAI GPT-3.5 Turbo to translate natural language queries into SQL.
+> Semantic Query uses OpenAI GPT-4.1 Mini to translate natural language queries into SQL.

--- a/src/lib/server/ai/index.ts
+++ b/src/lib/server/ai/index.ts
@@ -8,7 +8,7 @@ debug.enable("aid*");
 const log = debug("assistant");
 log.enabled = true;
 
-const OPENAI_MODEL = env.OPENAI_MODEL || "gpt-3.5-turbo-1106";
+const OPENAI_MODEL = env.OPENAI_MODEL || "gpt-4.1-mini";
 const CFAI_MODEL = env.CFAI_MODEL || "@cf/mistral/mistral-7b-instruct-v0.1";
 
 /**


### PR DESCRIPTION
Time flies... Now we have GPT-4.1...

This pull request updates the default OpenAI model used for Semantic Query from `gpt-3.5-turbo-1106` to `gpt-4.1-mini` across documentation and code. This change ensures consistency and reflects the adoption of a newer model.

### Updates to OpenAI model:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L51-R51): Updated the default OpenAI API model for Semantic Query from `gpt-3.5-turbo-1106` to `gpt-4.1-mini` in the "OpenAI API" section.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L70-R70): Updated the description in the "Cloudflare AI Worker" section to indicate that Semantic Query now uses `gpt-4.1-mini` instead of `gpt-3.5-turbo`.
* [`src/lib/server/ai/index.ts`](diffhunk://#diff-3dda647bef6c16fe91d36edcd3f10366904a3d408510dad2e81182b9dd793038L11-R11): Changed the fallback value for the `OPENAI_MODEL` environment variable from `gpt-3.5-turbo-1106` to `gpt-4.1-mini`.