### PR TITLE
feat: remove deprecated cloudflare ai package

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
 		"@ai-d/aid": "^0.1.5",
 		"@changesets/changelog-github": "^0.5.0",
 		"@changesets/cli": "^2.27.1",
-		"@cloudflare/ai": "^1.0.47",
 		"@cloudflare/workers-types": "^4.20240117.0",
 		"@iconify/svelte": "^3.1.6",
 		"@playwright/test": "^1.41.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		".svelte-kit/cloudflare"
 	],
 	"scripts": {
-		"prepare": "husky install && tsup src/cfai.ts -d cfai --format esm --minify",
+		"prepare": "husky install",
 		"dev": "vite dev",
 		"build": "vite build",
 		"preview": "vite preview",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ devDependencies:
     "@changesets/cli":
         specifier: ^2.27.1
         version: 2.27.1
-    "@cloudflare/ai":
-        specifier: ^1.0.47
-        version: 1.0.47
     "@cloudflare/workers-types":
         specifier: ^4.20240117.0
         version: 4.20240117.0
@@ -484,13 +481,6 @@ packages:
             fs-extra: 7.0.1
             human-id: 1.0.2
             prettier: 2.8.8
-        dev: true
-
-    /@cloudflare/ai@1.0.47:
-        resolution:
-            {
-                integrity: sha512-HRCIrSPrC3mXtIhbWQsSZAQxKHeiQxsjLPy0LHPrkZMzIFevJREINSNEhEccU/kDREkyPlzU5vV4++Yldbqqsg==,
-            }
         dev: true
 
     /@cloudflare/kv-asset-handler@0.2.0:

--- a/src/cfai.ts
+++ b/src/cfai.ts
@@ -1,1 +1,0 @@
-export * from "@cloudflare/ai";

--- a/src/lib/server/ai/index.ts
+++ b/src/lib/server/ai/index.ts
@@ -51,8 +51,7 @@ export async function select_backend(): Promise<AiBackend> {
 	if (env.AI) {
 		log("using Cloudflare backend");
 		return Aid.chat(async (messages) => {
-			const { Ai } = await import("$lib/../../cfai/cfai");
-			const ai = new Ai(env.AI);
+			const ai = env.AI as any;
 			const { response } = await ai.run(CFAI_MODEL, {
 				messages,
 			});


### PR DESCRIPTION
This pull request removes the dependency on the `@cloudflare/ai` package and updates the codebase to reflect this change. The most important changes involve removing the package from dependencies, cleaning up related exports, and modifying the backend logic to no longer rely on the `@cloudflare/ai` library.

### Dependency Removal:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L27): Removed the `@cloudflare/ai` package from the list of dependencies.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL17-L19): Removed all references to `@cloudflare/ai` in both `devDependencies` and `packages` sections. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL17-L19) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL489-L495)

### Codebase Updates:

* [`src/cfai.ts`](diffhunk://#diff-960fdeefdb6b33bb25b47af04486416249e1929d82418a802e3f36b7186c413eL1): Removed the export statement for `@cloudflare/ai`, as the package is no longer used.
* [`src/lib/server/ai/index.ts`](diffhunk://#diff-3dda647bef6c16fe91d36edcd3f10366904a3d408510dad2e81182b9dd793038L54-R54): Updated the `select_backend` function to remove the dynamic import of `@cloudflare/ai` and replaced the `Ai` class instantiation with a generic `env.AI` reference.